### PR TITLE
forms submissions query endpoint as swagger

### DIFF
--- a/oas/form-submissions.yaml
+++ b/oas/form-submissions.yaml
@@ -66,8 +66,8 @@ paths:
             (Not to be confused with no matching submissions)
 
 servers:
-  - url: https://app.proofgov.com/v1/api
-  - url: https://trac.ynet.gov.yk.ca/v1/api
+  - url: https://app.proofgov.com/api
+  - url: https://trac.ynet.gov.yk.ca/api
 
 components:
   schemas:

--- a/oas/form-submissions.yaml
+++ b/oas/form-submissions.yaml
@@ -49,7 +49,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/FormSubmission'
         '400':
-          description: malformed input
+          description: |
+            Malformed filters
+            (Do your filter parameters reference real attributes on the form?)
+        '401':
+          description: |
+            authentication failure
+            (Are you presenting a valid token and formatted correctly in the header?)
+        '403':
+          description: |
+            Authorization failure
+            (Your token was recognized, but you do not have rights to retrieve submissions for this form)
+        '404':
+          description: |
+            Form not found.
+            (Not to be confused with no matching submissions)
 
 servers:
   - url: https://app.proofgov.com/v1/api

--- a/oas/form-submissions.yaml
+++ b/oas/form-submissions.yaml
@@ -70,6 +70,9 @@ components:
           type: integer
         content:
           type: array
+          description: |
+            This is normalized response data.
+            Familiarity with the form schema will be needed to interpret certain questions.
           items:
             type: object
             additionalProperties:

--- a/oas/form-submissions.yaml
+++ b/oas/form-submissions.yaml
@@ -1,0 +1,88 @@
+openapi: 3.0.3
+info:
+  title: Form Submissions API
+  version: "1.0.0"
+  description: |
+    API endpoints to access Form Submissions
+  contact:
+    email: tech@proofgov.com
+  license:
+    name: Proof
+    url: 'https://proofgov.com/termsandconditions'
+
+paths:
+  /forms/{formId}/submissions:
+    get:
+      summary: Get a list of submissions for a particular form
+      parameters:
+        - in: path
+          name: formId
+          description: |
+            The ID of the particular form.
+          schema:
+            type: integer
+          required: true
+        - in: query
+          name: filters
+          description: |
+            Any filters to apply to result set before returning
+            (e.g. binding X = Y)
+          required: false
+          schema:
+            type: array
+            items:
+              type: object
+              additionalProperties:
+                anyOf:
+                  - type: string
+                  - type: number
+                  - type: boolean
+          style: deepObject
+          explode: true
+      responses:
+        '200':
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FormSubmission'
+        '400':
+          description: malformed input
+
+servers:
+  - url: https://app.proofgov.com/v1/api
+  - url: https://trac.ynet.gov.yk.ca/v1/api
+
+components:
+  schemas:
+    FormSubmission:
+      type: object
+      required:
+        - id
+        - formId
+        - content
+      properties:
+        id:
+          type: integer
+        formId:
+          type: integer
+        content:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+
+  securitySchemes:
+    bearerAuth: # arbitrary name for the security scheme
+      type: http
+      scheme: bearer
+
+# Everything in this API requires Bearer Auth
+security:
+  - bearerAuth: [] 


### PR DESCRIPTION
## Overview

This PR commits an OpenAPI v3 compatible documentation of a form submission API largely based on what was discussed (see [EV-1235](https://proof-tech.atlassian.net/browse/EV-1235) and [here](https://docs.google.com/document/d/146shjkV7YEuqlhSY5IzFv98OZLWmg-WvnGulrWGRND0/edit#)).

This will be presented to YG tomorrow, Friday May 15th at 3pm PT.

## Example invocations

/v1/api/forms/1/submissions
/v1/api/forms/1/submissions?filters[officeUse.portOfEntry]=2&filters[createdAt]=2020-04-16

## Notes

* We had discussed a simpler filter specification (as bare parameters). The above style was chosen based on a review of what's possible in parameter definition (for details, [see this section of OAS](https://swagger.io/docs/specification/serialization/))
* The FormSubmission schema mentions only a `content` section. I envision this for _normalized data_. (i.e. for selects, that's values not labels). I envision later extending this to also include a _denormalized data section_, or an alternative API that would allow users to denormalize that data.
* The response formatting section of FormSubmission end-point doesn't mention pagination. We can include this in a future API update.

See this on Swagger [here](https://app.swaggerhub.com/apis/proofgov/form-submissions/1.0.0)